### PR TITLE
Fix Fatal Error on Empty Sitemap

### DIFF
--- a/Sitemap.php
+++ b/Sitemap.php
@@ -218,6 +218,9 @@ class Sitemap {
 	 *
 	 */
 	private function endSitemap() {
+		if (!$this->getWriter()) {
+			$this->startSitemap();
+		}
 		$this->getWriter()->endElement();
 		$this->getWriter()->endDocument();
 	}


### PR DESCRIPTION
Fix Fatal Error on Empty Sitemap
- Check if sitemap has been started by checking `$this->getWriter()`
- If not run `$this->startSitemap()`

This situation can occur if no items were added to the sitemap
