### PR TITLE
Allow null $location param in the constructor and sanitize it

### DIFF
--- a/src/WebSitemapItem.php
+++ b/src/WebSitemapItem.php
@@ -62,7 +62,7 @@ class WebSitemapItem
      */
     public function setLocation($location)
     {
-        $this->location = $location;
+        $this->location = rtrim(strtolower($location));
 
         return $this;
     }

--- a/src/WebSitemapItem.php
+++ b/src/WebSitemapItem.php
@@ -62,7 +62,7 @@ class WebSitemapItem
      */
     public function setLocation($location)
     {
-        $this->location = rtrim(strtolower($location));
+        $this->location = rtrim(strtolower($location), '/');
 
         return $this;
     }

--- a/src/WebSitemapItem.php
+++ b/src/WebSitemapItem.php
@@ -40,9 +40,11 @@ class WebSitemapItem
      * WebSitemapItem constructor.
      * @param string $location
      */
-    public function __construct($location)
+    public function __construct($location = null)
     {
-        $this->location = $location;
+        if (null !== $location) {
+            $this->location = $location;
+        }
     }
 
     /**
@@ -55,10 +57,14 @@ class WebSitemapItem
 
     /**
      * @param string $location
+     *
+     * @return object $this 
      */
     public function setLocation($location)
     {
         $this->location = $location;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
For type-hinting reason, we should set $location parameter in the constructor of WebSitemapItem class to null value which enables to use setLocation method from type-hinting